### PR TITLE
Add sparklines to clickable table

### DIFF
--- a/vizstorm_sites/run_app.R
+++ b/vizstorm_sites/run_app.R
@@ -4,5 +4,7 @@ library(shiny)
 # library(shinycssloaders)
 # library(DT)
 # library(leaflet)
-
+# library(sparkline)
+# library(htmlwidgets)
+# library(tidyr)
 shiny::runApp("vizstorm_sites/vizstorm_app", launch.browser = TRUE)

--- a/vizstorm_sites/vizstorm_app/server.R
+++ b/vizstorm_sites/vizstorm_app/server.R
@@ -67,23 +67,7 @@ shiny::shinyServer(function(input, output,session) {
         leaflet::setView(lng = -82.3, lat = 34.25, zoom=6)    
     })
   })
-  
-  # observeEvent(input$sitesDT_rows_selected, {
-  #   
-  #   rows_DT <- input$sitesDT_rows_selected
-  #   if(is.null(rows_DT)){
-  #     return() 
-  #   }
-  # 
-  #   sites <- isolate(siteDF[["lat_lon"]][["site_no"]])
-  # 
-  #   siteDF[["clicked_table_site"]] <-  sites[rows_DT]
-  #   
-  #   new_picks <- unique(c(siteDF[["clicked_table_site"]],siteDF[["clicked_map_site"]]))
-  #   siteDF[["picked_sites"]] <- new_picks
-  #   siteDF[["lat_lon"]][["picked_sites"]] <- siteDF[["lat_lon"]][["site_no"]] %in% new_picks
-  # })
-  
+
   observeEvent(input$sparkTable_rows_selected, {
     
     rows_DT <- input$sparkTable_rows_selected
@@ -218,8 +202,7 @@ shiny::shinyServer(function(input, output,session) {
                                 opacity = 0.8,
                                 stroke=FALSE)
   })
-  
-  # proxy = dataTableProxy('sitesDT')
+
   proxy_sparky = dataTableProxy('sparkTable')
   
   output$sparkTable <- DT::renderDataTable({
@@ -236,7 +219,6 @@ shiny::shinyServer(function(input, output,session) {
     site_df <- siteDF[["lat_lon"]]
 
     stream_data <- stream_data %>%
-      # filter(site_no %in% sites_to_show) %>%
       left_join(select(site_df, station_nm, site_no, drain_area_va), by="site_no")
     
     max_stream <- stream_data %>%
@@ -275,26 +257,10 @@ shiny::shinyServer(function(input, output,session) {
     d1$dependencies <- append(d1$dependencies, htmlwidgets:::getDependency("sparkline"))
     d1
     # Next step....
-    # Then...Let that table *also* click on/off sites.
+    # Don't re-do whole table
     
     
   })
-  
-  # output$sitesDT <- DT::renderDataTable({
-  #   
-  #   sites_dt <- siteDF[["lat_lon"]]
-  #   
-  #   validate(
-  #     need(nrow(sites_dt) > 0, "Please select a data set")
-  #   )
-  #   
-  #   sites_dt <- dplyr::select(sites_dt, site_no, station_nm, drain_area_va, has_flooded, picked_sites)
-  #   picked_index <- which(sites_dt$picked_sites)
-  #   DT::datatable(dplyr::select(sites_dt, -picked_sites),
-  #                 rownames = FALSE, 
-  #                 selection = list(selected = picked_index))
-  #   
-  # })
   
   output$downloadSites <- downloadHandler(
     
@@ -302,8 +268,6 @@ shiny::shinyServer(function(input, output,session) {
     
     content = function(file) {
       x <- siteDF[["lat_lon"]]
-      # sites_to_show <- siteDF[["picked_sites"]]
-      # x <- filter(x, site_no %in% sites_to_show)
       saveRDS(file = file, object = x)
     }
   )

--- a/vizstorm_sites/vizstorm_app/ui.R
+++ b/vizstorm_sites/vizstorm_app/ui.R
@@ -39,8 +39,6 @@ body <- dashboardBody(
              column(3, downloadButton('downloadSites', 'Download RDS'))
            ),
            tabBox(width = 12, id="mainOut",
-                  # tabPanel(title = tagList(title = "Table", shiny::icon("bars")), value = "table",
-                  #          shinycssloaders::withSpinner(DT::dataTableOutput('sitesDT'))),
                   tabPanel(title = tagList(title = "Sparklines Table"), value = "sparks",
                            shinycssloaders::withSpinner(DT::dataTableOutput('sparkTable'))),
                   tabPanel(title = tagList(title = "Sparklines ggplot"), value = "sparks",

--- a/vizstorm_sites/vizstorm_app/ui.R
+++ b/vizstorm_sites/vizstorm_app/ui.R
@@ -1,8 +1,10 @@
 library(shiny)
 library(shinydashboard)
 library(dplyr)
+library(tidyr)
 library(ggplot2)
 library(DT)
+library(sparkline)
 
 header <- dashboardHeader(title = "Pick sites",
                           tags$li(class = "dropdown", 
@@ -25,21 +27,23 @@ header <- dashboardHeader(title = "Pick sites",
                           )))
 
 body <- dashboardBody(
+
   fluidRow(
-    column(6, fileInput("site_data", "Load all_flow and all_sites (RDS)",multiple = TRUE)),
-    column(6, downloadButton('downloadSites', 'Download RDS'))
-  ),
-  
-  fluidRow(
-    column(6, 
+    column(5, 
            h4("Size relates to drainage area"),
            h4("Opacity relates to period of record"),
-           shinycssloaders::withSpinner(leaflet::leafletOutput("mymap",height = "700px"))),
-    column(6, 
+           shinycssloaders::withSpinner(leaflet::leafletOutput("mymap",height = "500px"))),
+    column(7, 
+           fluidRow(
+             column(3, fileInput("site_data", "Load all_flow and all_sites (RDS)",multiple = TRUE)),
+             column(3, downloadButton('downloadSites', 'Download RDS'))
+           ),
            tabBox(width = 12, id="mainOut",
-                  tabPanel(title = tagList(title = "Table", shiny::icon("bars")), value = "table",
-                           shinycssloaders::withSpinner(DT::dataTableOutput('sitesDT'))),
-                  tabPanel(title = tagList(title = "Sparklines"), value = "sparks",
+                  # tabPanel(title = tagList(title = "Table", shiny::icon("bars")), value = "table",
+                  #          shinycssloaders::withSpinner(DT::dataTableOutput('sitesDT'))),
+                  tabPanel(title = tagList(title = "Sparklines Table"), value = "sparks",
+                           shinycssloaders::withSpinner(DT::dataTableOutput('sparkTable'))),
+                  tabPanel(title = tagList(title = "Sparklines ggplot"), value = "sparks",
                            plotOutput("sparks",height = 1000,width = 600))
            ))
   )


### PR DESCRIPTION
![s3](https://user-images.githubusercontent.com/1105215/46834806-0c3b9f80-cd72-11e8-8221-247f12b5f169.gif)

Rebuilds the table after each selection, which is annoying, but it seems to be working otherwise. Maybe someday I'll find the argument to not rebuild the table each time. I think it has something to do with the sparkline dependency, but not sure.