### PR TITLE
Idea blitz: 500 days of flooding pipeline

### DIFF
--- a/500_days_of_flooding/remake.yml
+++ b/500_days_of_flooding/remake.yml
@@ -22,6 +22,7 @@ targets:
       - site_locations_map.png
       - streamgraph.html
       - streamgraph.png
+      - streamgraph.svg
 
 ## -- Identify which sites to use -- ##
 
@@ -125,3 +126,5 @@ targets:
     command: saveWidget(streamgraph_widget, target_name)
   streamgraph.png:
     command: save_png(streamgraph_widget, target_name)
+  streamgraph.svg:
+    command: save_svg('streamgraph.html', target_name)

--- a/500_days_of_flooding/remake.yml
+++ b/500_days_of_flooding/remake.yml
@@ -80,6 +80,9 @@ targets:
   
 ## -- Pulling and processing ref data -- ##
   
+  # TODO: there are other sites where there is Flow but not GH. Should we use rating
+  # curves there, too?
+  
   # Use the earliest date from the soi data to determine
   # how much of the reference sites to pull
   earliest_date:

--- a/500_days_of_flooding/remake.yml
+++ b/500_days_of_flooding/remake.yml
@@ -49,12 +49,13 @@ targets:
   # site only has GH back to 2017 (uv or dv), so I am going to pull flow
   # data and convert to GH. I also know that the site has flow data starting
   # in 1950, but it is not continuous and there is a very large gap from
-  # 1977-04-19 to 1999-10-01. I am going to start in 1999 to avoid the gap.
+  # 1977-04-19 to 1999-10-01. I am going to start in 2000 to avoid the gap
+  # and start with a whole year.
   soi_data:
     command: get_nwis_data(
       soi,
       pcode = I("00060"),
-      startDate = I("1999-10-01"))
+      startDate = I("2000-01-01"))
   
   # Since we don't have GH very far back, we use 
   # the site's rating curve to approximate Q for flood stage.

--- a/500_days_of_flooding/remake.yml
+++ b/500_days_of_flooding/remake.yml
@@ -1,0 +1,116 @@
+target_default: 500_days_of_flooding
+
+packages:
+  - dataRetrieval
+  - dplyr
+  - htmlwidgets
+  - maps
+  - purrr
+  - sf
+  - streamgraph
+
+sources:
+  - src/fetch.R
+  - src/process.R
+  - src/visualize.R
+
+targets:
+  500_days_of_flooding:
+    depends:
+      - site_locations_map.png
+      - streamgraph.html
+
+## -- Identify which sites to use -- ##
+
+  # "06472000" # 545 days, Q since 1999, GH since 2017
+  # "06471000" # 513 days, Q since 1991, GH since 2018
+  
+  # `soi` = site of interest
+  soi:
+    command: c(I("06472000"))
+  
+  # `ref` = reference
+  ref_site_info:
+    command: identify_ref_sites(soi_info, earliest_date, nws_flood_stage_info)
+  ref_sites:
+    command: pull(ref_site_info, I("site_no"))
+  
+## -- Get flood info from National Weather Service -- ##
+  
+  nws_flood_stage_info:
+    command: get_nws_flood_info()
+  
+## -- Pulling and processing soi data -- ##
+  
+  soi_info:
+    command: readNWISsite(soi)
+  
+  # Download site of interest data - I know from  earlier tests that this
+  # site only has GH back to 2017 (uv or dv), so I am going to pull flow
+  # data and convert to GH. I also know that the site has flow data starting
+  # in 1950, but it is not continuous and there is a very large gap from
+  # 1977-04-19 to 1999-10-01. I am going to start in 1999 to avoid the gap.
+  soi_data:
+    command: get_nwis_data(
+      soi,
+      pcode = I("00060"),
+      startDate = I("1999-10-01"))
+  
+  # Since we don't have GH very far back, we use 
+  # the site's rating curve to approximate Q for flood stage.
+  soi_rating:
+    command: readNWISrating(soi)
+  soi_gh_data:
+    command: add_gage_height(soi_data, soi_rating)
+  
+## -- Summarizing soi flood data -- ##
+
+  # Add T/F column indicating whether or not the site is flooding for every day
+  soi_flooding:
+    command: identify_flooding(
+      soi_gh_data,
+      nws_flood_stage_info,
+      flood_type = I("flood_stage"))
+  # Group flooding into different flood events and determine length of each event
+  soi_flood_evts:
+    command: summarize_flood_events(soi_flooding)
+  # Summarize flood data annually by finding the longest flood event for each year
+  soi_max_annual_flood_evt:
+    command: find_longest_annual_floods(soi_flood_evts)
+  
+## -- Pulling and processing ref data -- ##
+  
+  # Use the earliest date from the soi data to determine
+  # how much of the reference sites to pull
+  earliest_date:
+    command: get_min_date(soi_data)
+  ref_gh_data:
+    command: get_nwis_data(
+      ref_sites,
+      pcode = I("00065"),
+      startDate = earliest_date)
+  
+## -- Summarizing ref flood data -- ##
+
+  # Add T/F column indicating whether or not the site is flooding for every day
+  ref_flooding:
+    command: identify_flooding(
+      ref_gh_data,
+      nws_flood_stage_info,
+      flood_type = I("flood_stage"))
+  # Group flooding into different flood events and determine length of each event
+  ref_flood_evts:
+    command: summarize_flood_events(ref_flooding)
+  # Summarize flood data annually by finding the longest flood event for each year
+  ref_max_annual_flood_evt:
+    command: find_longest_annual_floods(ref_flood_evts)
+  
+## -- Visualizing data -- ##
+
+  # Map of sites used
+  site_locations_map.png:
+    command: make_site_location_map(target_name, soi_info, ref_site_info)
+  
+  # Create the streamgraph
+  streamgraph.html:
+    command: make_streamgraph(target_name, soi_max_annual_flood_evt, ref_max_annual_flood_evt)

--- a/500_days_of_flooding/remake.yml
+++ b/500_days_of_flooding/remake.yml
@@ -3,11 +3,13 @@ target_default: 500_days_of_flooding
 packages:
   - dataRetrieval
   - dplyr
+  - htmltools
   - htmlwidgets
   - maps
   - purrr
   - sf
   - streamgraph
+  - webshot # Need to run `webshot::install_phantomjs()` once too
 
 sources:
   - src/fetch.R
@@ -19,6 +21,7 @@ targets:
     depends:
       - site_locations_map.png
       - streamgraph.html
+      - streamgraph.png
 
 ## -- Identify which sites to use -- ##
 
@@ -116,5 +119,9 @@ targets:
     command: make_site_location_map(target_name, soi_info, ref_site_info)
   
   # Create the streamgraph
+  streamgraph_widget:
+    command: make_streamgraph(soi_max_annual_flood_evt, ref_max_annual_flood_evt)
   streamgraph.html:
-    command: make_streamgraph(target_name, soi_max_annual_flood_evt, ref_max_annual_flood_evt)
+    command: saveWidget(streamgraph_widget, target_name)
+  streamgraph.png:
+    command: save_png(streamgraph_widget, target_name)

--- a/500_days_of_flooding/src/fetch.R
+++ b/500_days_of_flooding/src/fetch.R
@@ -10,10 +10,7 @@ get_nwis_data <- function(sites, pcode, startDate) {
 }
 
 identify_ref_sites <- function(soi_info, earliest_date_to_use, flood_info) {
-  
-  # TODO: remove this random selection of only 3 sites
-  set.seed(19)
-  
+
   # Use drainage area to find sites that are similar to the soi
   soi_drain_area <- soi_info$drain_area_va
   min_drain_area <- soi_drain_area - soi_drain_area*0.25
@@ -35,7 +32,5 @@ identify_ref_sites <- function(soi_info, earliest_date_to_use, flood_info) {
     filter(site_no != soi_info$site_no) %>%  
     # Only keep sites that have flood stage available
     left_join(flood_info, by='site_no') %>% 
-    filter(!is.na(flood_stage)) %>% 
-    # TODO: remove this random selection of only 3 sites
-    sample_n(3)
+    filter(!is.na(flood_stage)) 
 }

--- a/500_days_of_flooding/src/fetch.R
+++ b/500_days_of_flooding/src/fetch.R
@@ -1,0 +1,41 @@
+# Get join NWS flood stage table
+get_nws_flood_info <- function() {
+  nws_flood_stage_list <- jsonlite::fromJSON("https://waterwatch.usgs.gov/webservices/floodstage?format=json")
+  return(nws_flood_stage_list[["sites"]])
+}
+
+get_nwis_data <- function(sites, pcode, startDate) {
+  readNWISdv(sites, parameterCd = pcode, startDate = startDate) %>% 
+      renameNWISColumns()
+}
+
+identify_ref_sites <- function(soi_info, earliest_date_to_use, flood_info) {
+  
+  # TODO: remove this random selection of only 3 sites
+  set.seed(19)
+  
+  # Use drainage area to find sites that are similar to the soi
+  soi_drain_area <- soi_info$drain_area_va
+  min_drain_area <- soi_drain_area - soi_drain_area*0.25
+  max_drain_area <- soi_drain_area + soi_drain_area*0.25
+  
+  # Cycle through each HUC02 to figure out if there are any sites
+  purrr::map(sprintf("%02d", 1:21), function(huc) {
+    message(sprintf("Trying HUC %s ...", huc))
+    # Some HUCs fail bc of no data to return
+    tryCatch(
+      whatNWISsites(huc = huc, parameterCd = c("00065"), startDate = earliest_date_to_use,
+                  drainAreaMin = min_drain_area, drainAreaMax = max_drain_area) %>% 
+      select(site_no, station_nm, dec_lat_va, dec_long_va),
+      error = function(e) return()
+    )
+  }) %>%
+    bind_rows() %>%
+    # Remove the current soi from this list
+    filter(site_no != soi_info$site_no) %>%  
+    # Only keep sites that have flood stage available
+    left_join(flood_info, by='site_no') %>% 
+    filter(!is.na(flood_stage)) %>% 
+    # TODO: remove this random selection of only 3 sites
+    sample_n(3)
+}

--- a/500_days_of_flooding/src/process.R
+++ b/500_days_of_flooding/src/process.R
@@ -7,7 +7,8 @@ get_min_date <- function(nwis_data) {
 add_gage_height <- function(nwis_data, rating_curve) {
   # Add GH (DEP = flow, INDEP = gage height)
   nwis_data$GH <- approx(rating_curve$DEP, rating_curve$INDEP, nwis_data$Flow)$y
-  nwis_data$GH_cd <- NULL
+  # Since GH is derived from Flow in this scenario, have the cd match
+  nwis_data$GH_cd <- nwis_data$Flow_cd 
   return(nwis_data)
 }
 

--- a/500_days_of_flooding/src/process.R
+++ b/500_days_of_flooding/src/process.R
@@ -1,0 +1,63 @@
+
+# Find minimum date in a daily dataset
+get_min_date <- function(nwis_data) {
+  min(nwis_data$Date)
+}
+
+add_gage_height <- function(nwis_data, rating_curve) {
+  # Add GH (DEP = flow, INDEP = gage height)
+  nwis_data$GH <- approx(rating_curve$DEP, rating_curve$INDEP, nwis_data$Flow)$y
+  return(nwis_data)
+}
+
+# Using gage height and NWS flood stage, identify when a gage is flooding
+identify_flooding <- function(gh_data, flood_info, flood_type = c("flood_stage", "moderate_flood_stage", "major_flood_stage")) {
+  gh_data %>% 
+    # TODO: how is this impacted by ICE?????
+    filter(!is.na(GH)) %>% # Needs to have a GH 
+    left_join(flood_info, by='site_no') %>%
+    rename(flood_val = !!flood_type) %>% # Use the desired flood column
+    mutate(is_flooding = GH >= as.numeric(flood_val)) %>%
+    mutate(year = as.numeric(format(Date, "%Y"))) %>% 
+    select(site_no, Date, year, GH, is_flooding)
+}
+
+# Using consecutive days of flooding, determine how many days 
+summarize_flood_events <- function(flood_data) {
+  flood_data %>%
+    group_by(site_no) %>%
+    
+    # Identify individual flood events by identifying consecutive flooding 
+    # days and assigning a number every time the following day is not flooding.
+    # This means that the non-flooding days before a flood event are included.
+    mutate(flood_evt = cumsum(c(FALSE, diff(is_flooding) < 0))) %>% 
+    
+    # Add column of cumulative consecutive flooding days for event
+    mutate(cumulative_flood_days = count_consecutive_flood_days_per_evt(is_flooding, flood_evt)) %>% 
+    
+    # Remove days that are not flooding before summarizing event lengths. Would be  
+    # confusing because days with no flood could end up with a max flood evt length
+    filter(cumulative_flood_days > 0) %>%
+    
+    # Determine the length of each flood event
+    group_by(site_no, flood_evt) %>% 
+    mutate(flood_evt_length = max(cumulative_flood_days)) %>% 
+    ungroup()
+}
+
+# Use this to accumulate flood days for each event
+count_consecutive_flood_days_per_evt <- function(bool_col, grp) {
+  cumul_days <- unlist(lapply(split(bool_col, grp), cumsum))
+  names(cumul_days) <- NULL
+  return(cumul_days)
+}
+
+# For each site, identify the longest flood of every year
+find_longest_annual_floods <- function(flood_evt_data) {
+  flood_evt_data %>% 
+    group_by(site_no, year) %>% 
+    # TODO: decide what to do about events that span a year. 
+    #   can limit to each year by summarizing the prev fxn
+    #   using evt id made up of year + flood?
+    summarize(max_flood_evt_duration = max(flood_evt_length))
+}

--- a/500_days_of_flooding/src/process.R
+++ b/500_days_of_flooding/src/process.R
@@ -39,7 +39,7 @@ identify_flooding <- function(gh_data, flood_info, flood_type = c("flood_stage",
 find_prev_next_open_water_val <- function(data) {
   data %>% 
     group_by(site_no) %>%
-    mutate(is_ice = Flow_cd == "P Ice") %>% 
+    mutate(is_ice = !is.na(GH_cd) & GH_cd == "P Ice") %>% 
     # Identify individual ice periods by identifying consecutive ice days and 
     # assigning a number every time the following day does not have "P Ice". 
     # The open water days leading up to an ice period are included.

--- a/500_days_of_flooding/src/scratch_tons_of_plots.R
+++ b/500_days_of_flooding/src/scratch_tons_of_plots.R
@@ -1,0 +1,447 @@
+# Code is too scratchy for even putting in the pipeline, but wanted to include this for posterity. 
+
+library(dataRetrieval)
+library(dplyr)
+library(tidyr)
+library(ggplot2)
+
+site1 <- "06472000" # 545 days, Q since 1999, GH since 2017
+site2 <- "06471000" # 513 days, Q since 1991, GH since 2018
+
+sites_df <- readNWISsite(site1)
+
+# Get and join NWS flood stage table
+nws_flood_stage_list <- jsonlite::fromJSON("https://waterwatch.usgs.gov/webservices/floodstage?format=json")
+nws_flood_stage_table <- nws_flood_stage_list[["sites"]]
+sites_df <- sites_df %>%
+  select(site_no, station_nm, dec_lat_va, dec_long_va) %>% 
+  left_join(nws_flood_stage_table, by='site_no')
+
+
+# Since we only have GH back to 2018-05-01 for site1,
+# use rating curve to approximate Q for flood stage.
+site_rating_curve <- readNWISrating(sites_df$site_no)
+site_curve_gh <- site_rating_curve$INDEP
+site_curve_q <- site_rating_curve$DEP
+flood_q <- approx(site_curve_gh, site_curve_q, sites_df$flood_stage)$y
+flood_q_mod <- approx(site_curve_gh, site_curve_q, sites_df$moderate_flood_stage)$y
+flood_q_maj <- approx(site_curve_gh, site_curve_q, sites_df$major_flood_stage)$y
+
+# DOWNLOAD FLOW
+q_data <- readNWISdv(sites_df$site_no, parameterCd = "00060") %>% 
+  renameNWISColumns() %>% 
+  mutate(year = as.numeric(format(Date, "%Y")))
+
+# COUNT FLOODING DAYS
+count_consecutive_flood_days <- function(bool_col, grp) {
+  unlist(lapply(split(bool_col, grp), cumsum))
+}
+
+q_data_flood <- q_data %>% 
+  # For now treating all ice days as flood
+  mutate(is_flooding = Flow >= flood_q | Flow_cd == "P Ice") %>% # Could be NA due to ice
+  filter(year >= 1999) %>% 
+  # Identify groups of consecutive flooding days
+  mutate(grp = cumsum(c(FALSE, diff(is_flooding) < 0))) %>% 
+  # Count consecutive flooding days
+  mutate(cumulative_consecutive_flood = count_consecutive_flood_days(is_flooding, grp)) %>% 
+  group_by(grp) %>% 
+  mutate(grp_max = max(cumulative_consecutive_flood),
+         cum_q = cumsum(Flow))
+
+##### Sailboat plots #####
+q_data_flood %>% 
+  ggplot(aes(x = Date, y = cumulative_consecutive_flood)) +
+  geom_line() +
+  # geom_curve(aes(xend = lag(Date), yend = lag(cumulative_consecutive_flood))) +
+  ggtitle(sites_df$site_no) +
+  ggtitle("TEST 1: Compare flood events through time based on duration & magnitude")
+
+# Make peaks look like waves
+q_data_flood %>% 
+  ggplot(aes(x = Date, y = cumulative_consecutive_flood), fill = grp_max) +
+  geom_polygon() + 
+  scale_color_gradient2(low = "lightblue", high = "darkblue") +
+  # geom_curve(aes(xend = lag(Date), yend = lag(cumulative_consecutive_flood))) +
+  ggtitle(sites_df$site_no)+
+  ggtitle("TEST 2: Compare flood events through time based on duration & magnitude")
+
+
+###### Bar plot: width = span, height = max number of consecutive days #####
+
+# Try to get magnitude + duration
+
+# Bar height = max flow of event
+# Bar width = max # consecutive days of event
+# Bar position = median date of event
+
+q_data_flood %>% 
+  filter(cumulative_consecutive_flood > 0) %>% 
+  group_by(grp) %>% 
+  summarize(bar_height = max(Flow),
+            bar_width = max(cumulative_consecutive_flood),
+            bar_x_loc = median(Date)) %>%
+  mutate(bar_x1 = bar_x_loc - bar_width/2,
+         bar_x2 = bar_x_loc + bar_width/2) %>% 
+  ggplot(aes(xmin = bar_x1, xmax = bar_x2, ymax = bar_height)) +
+  geom_rect(ymin = 0) + 
+  geom_hline(yintercept = flood_q, color = "orange", linetype = "dashed", size = 1) +
+  geom_hline(yintercept = flood_q_mod, color = "red", linetype = "dashed", size = 1) +
+  geom_hline(yintercept = flood_q_maj, color = "maroon", linetype = "dashed", size = 1) + 
+  ylab("Peak Event Flow") + xlab("Days") +
+  ggtitle("TEST 3: Compare flood events through time based on duration & magnitude")
+
+
+##### Scatter plot style #####
+
+q_data_flood %>% 
+  filter(cumulative_consecutive_flood > 0) %>% 
+  group_by(grp) %>% 
+  summarize(x = median(Date),
+            y = max(cumulative_consecutive_flood),
+            size = max(Flow)) %>% 
+  ggplot(aes(x = x, y = y, size = size)) +
+  geom_point() +
+  ylab("Days of flooding") + xlab("Year") +
+  ggtitle("TEST 4: Compare flood events through time based on duration & magnitude")
+
+###### Heat Maps #####
+
+# Filled based on flow magnitude
+q_data_flood %>% 
+  mutate(doy = as.numeric(format(Date, "%j"))) %>% 
+  ggplot(aes(x = doy, y = year, fill = Flow)) +
+  geom_tile() +
+  theme_minimal() +
+  theme(panel.grid = element_blank()) +
+  scale_fill_gradient2(low="#DCEDC8", mid = "#42B3D5", high="#1A237E", midpoint = 5000) +
+  ggtitle("TEST 5: Heat map to show flow magnitude through time")
+
+# Filled based on binary idea of below or above flood
+q_data_flood %>% 
+  mutate(doy = as.numeric(format(Date, "%j"))) %>% 
+  ggplot(aes(x = doy, y = year, fill = is_flooding)) +
+  geom_tile() +
+  scale_fill_manual(values = c("lightgrey", "navy")) +
+  theme_minimal() +
+  theme(panel.grid = element_blank()) +
+  ggtitle("TEST 6: Heat map to show flood event occurrence")
+
+# Filled based on type of flood
+q_data_flood_levels <- q_data %>% 
+  # For now treating all ice days as flood
+  mutate(flood_type = 
+           ifelse(is.na(Flow), #Flow_cd == "P ice" | Flow_cd == "P Ice i" | 
+                  "UNKNOWN", 
+                  ifelse(Flow >= flood_q_maj,
+                         "Major flood",
+                         ifelse(Flow >= flood_q_mod,
+                                "Moderate flood",
+                                ifelse(Flow >= flood_q,
+                                       "Minor flood",
+                                       "No flood"))))
+  ) %>% # Could be NA due to ice
+  mutate(flood_type = factor(flood_type, levels = c("Major flood", "Moderate flood", "Minor flood", "No flood", "UNKOWN"))) %>% 
+  filter(year >= 1999) %>% 
+  mutate(doy = as.numeric(format(Date, "%j"))) 
+
+q_data_flood_levels %>% 
+  ggplot(aes(x = doy, y = year, fill = flood_type)) +
+  geom_tile() +
+  viridis::scale_fill_viridis(discrete = TRUE) +
+  theme_minimal() +
+  theme(panel.grid = element_blank()) +
+  ggtitle("TEST 7: Heat map to show difference in magnitude and duration flood events across time")
+
+##### Try a plot where we compare other sites of similar specs #####
+
+min_date_to_use <- min(q_data_flood$Date)
+similar_sites <- purrr::map(sprintf("%02d", 1:21), function(huc, drain_area) {
+  if(huc %in% c("04", "06", "20", "21")) return() # These HUCs failed bc of no data to return
+  whatNWISsites(huc = huc, parameterCd = c("00065"), startDate = min_date_to_use,
+    drainAreaMin = drain_area - drain_area*0.25, drainAreaMax = drain_area + drain_area*0.25) %>% 
+    select(site_no, station_nm, dec_lat_va, dec_long_va)
+}, drain_area = readNWISsite(site1)$drain_area_va) %>% bind_rows()
+
+other_sites_df <- similar_sites %>%
+  filter(site_no != site1) %>%  
+  left_join(nws_flood_stage_table, by='site_no') %>% 
+  filter(!is.na(flood_stage)) # Must have flood stage
+n_other_sites <- length(unique(other_sites_df$site_no))
+
+q_data_others <- readNWISdv(other_sites_df$site_no, parameterCd = "00065", startDate = min_date_to_use) %>% 
+  renameNWISColumns() %>% 
+  mutate(year = as.numeric(format(Date, "%Y"))) %>% 
+  left_join(other_sites_df, by = "site_no") %>% 
+  mutate(is_flooding = GH >= as.numeric(flood_stage)) %>% 
+  select(site_no, Date, GH, year, is_flooding)
+
+q_data_flood_others <- q_data_others %>% 
+  filter(!is.na(GH)) %>%
+  group_by(site_no) %>%
+  # Identify groups of consecutive flooding days
+  mutate(grp = sprintf("%s_%s", site_no, cumsum(c(FALSE, diff(is_flooding) < 0)))) %>% 
+  # Count consecutive flooding days
+  mutate(cumulative_consecutive_flood = count_consecutive_flood_days2(is_flooding, grp)) %>% 
+  group_by(site_no, grp) %>% 
+  mutate(grp_max = max(cumulative_consecutive_flood)) %>% 
+  ungroup()
+
+# Make a plot where the filled in polys are this site and the unfilled are
+#   the other sites
+ggplot() +
+  # geom_line(data = q_data_flood_others, aes(x = Date, y = cumulative_consecutive_flood, color = site_no)) +
+  geom_curve(data = q_data_flood, aes(x = Date, xend = lead(Date), y = cumulative_consecutive_flood, 
+                                      yend = lead(cumulative_consecutive_flood)), color = "#3f5f5c80", size=2) +
+  scale_color_manual(values = rep("#9f817f80", n_other_sites)) + # Make the background lines all the same color
+  # geom_hline(yintercept = max(q_data_flood_others$cumulative_consecutive_flood), color = "#5e696f", linetype = "dashed", size=0.8) +
+  # geom_text(
+  #   aes(x = min_date_to_use, y = max(q_data_flood_others$cumulative_consecutive_flood)),
+  #   label = sprintf("Maximum duration of consecutive flood\ndays from %s other similar sites", n_other_sites),
+  #   nudge_y = 30, hjust = 0) +
+  geom_text(aes(x = min_date_to_use, y = 500), label = "Site of interest", color = "#3f5f5c", size=8, fontface = "bold", hjust = 0) +
+  # geom_text(aes(x = min_date_to_use, y = 450), label = "Other sites to compare", color = "#9f817f", size=8, fontface = "bold", hjust = 0) +
+  guides(color = FALSE) +
+  theme_bw() +
+  ylab("Cumulative consecutive flood days") + xlab("Date") +
+  ggtitle("TEST 8: Compare flood events from other sites over time based on duration")
+
+##### A line + scatter chart hybrid #####
+
+# Inspired by https://www.nytimes.com/interactive/2017/09/01/upshot/cost-of-hurricane-harvey-only-one-storm-comes-close.html
+
+# Radius = consecutive days
+# Use data pulled from above to compare other similar sites to this one
+
+q_data_flood_arcs <- q_data_flood %>% 
+  filter(cumulative_consecutive_flood > 0) %>% 
+  group_by(grp) %>% 
+  summarize(bar_color = max(Flow),
+            arc_size = max(cumulative_consecutive_flood),
+            arc_x_loc = median(Date)) %>%
+  mutate(arc_x_loc_day = as.numeric(format(arc_x_loc, "%j")),
+         year = as.numeric(format(arc_x_loc, "%Y")))
+
+q_data_flood_arcs_others <- q_data_flood_others %>% 
+  filter(cumulative_consecutive_flood > 0) %>% 
+  group_by(site_no, grp) %>% 
+  summarize(bar_color = max(GH), # IF YOU USE THIS YOU ARE COMPARING GH TO FLOW (site1 only has q)
+            arc_size = max(cumulative_consecutive_flood),
+            arc_x_loc = median(Date)) %>%
+  mutate(arc_x_loc_day = as.numeric(format(arc_x_loc, "%j")),
+         year = as.numeric(format(arc_x_loc, "%Y")))
+
+ggplot() +
+  # All "other" sites
+  ggforce::geom_arc_bar(
+    data = q_data_flood_arcs_others, fill = "#9f817f80", color = NA,
+    aes(x0 = arc_x_loc_day, y0 = 0, r0 = 0, r = sqrt(arc_size), start = -pi/2, end = pi/2)) +
+  # This record-breaking site
+  ggforce::geom_arc_bar(
+    data = q_data_flood_arcs, fill = "#3f5f5c80", color = "#5e696f", size = 1,
+    aes(x0 = arc_x_loc_day, y0 = 0, r0 = 0, r = sqrt(arc_size), start = -pi/2, end = pi/2)) +
+  coord_fixed() +
+  ylab("Days of consecutive flooding") + xlab("Day of Year") +
+  geom_text(data=tibble(x = 0, y = 20, year = 1999), aes(x = x, y = y),
+            label = "Site of interest", color = "#3f5f5c", size=4.5, fontface = "bold", hjust = 0) +
+  geom_text(data=tibble(x = 0, y = 7, year = 1999), aes(x = x, y = y),
+            label = "Other sites to compare", color = "#9f817f", size=4.5, fontface = "bold", hjust = 0) +
+  facet_grid(rows = vars(year)) +
+  theme(panel.background = element_blank(), 
+        strip.background = element_blank(),
+        strip.text.y = element_text(angle = 0),
+        axis.text.y = element_blank(), 
+        axis.ticks.y = element_blank(),
+        plot.margin = unit(c(0, 0, 0, 0), "null")) +
+    ggtitle("TEST 9: Compare flood events from other sites over time based on duration using circles!")
+
+# Do a rectangle version of the above
+# similiar to: https://flowingdata.com/2020/09/10/a-timeline-of-california-wildfires/
+
+# Split grps if they span a year (they will still get the max value for peak consecutive flood days)
+q_data_flood_span_yrs <- q_data_flood %>% 
+  mutate(grp_new = sprintf("%s_%s", year, grp)) %>% 
+  filter(cumulative_consecutive_flood > 0) %>% 
+  group_by(grp_new) %>% 
+  summarize(site_no = unique(site_no),
+            year = unique(year),
+            peak_consecutive_flood_days = unique(grp_max),
+            start_Dt = min(Date),
+            end_Dt = max(Date),
+            x_start = as.numeric(format(min(Date), "%j")),
+            x_end = as.numeric(format(max(Date), "%j")))
+  
+q_data_flood_span_yrs_others <- q_data_flood_others %>% 
+  mutate(grp_new = sprintf("%s_%s", year, grp)) %>% 
+  filter(cumulative_consecutive_flood > 0) %>% 
+  group_by(grp_new) %>% 
+  summarize(site_no = unique(site_no),
+            year = unique(year),
+            peak_consecutive_flood_days = unique(grp_max),
+            start_Dt = min(Date),
+            end_Dt = max(Date),
+            x_start = as.numeric(format(min(Date), "%j")),
+            x_end = as.numeric(format(max(Date), "%j")))
+
+ggplot() +
+  # All "other" sites
+  geom_rect(
+    data = q_data_flood_span_yrs_others, fill = "#9f817f80", color = NA,
+    aes(xmin = x_start, xmax = x_end, ymin = 0, ymax = peak_consecutive_flood_days)) +
+  # This record-breaking site
+  geom_rect(
+    data = q_data_flood_span_yrs, fill = "#3f5f5c80", color = "#5e696f", size = 1,
+    aes(xmin = x_start, xmax = x_end, ymin = 0, ymax = peak_consecutive_flood_days)) +
+  geom_text(data=tibble(x = 0, y = 400, year = 1999), aes(x = x, y = y),
+            label = "Site of interest", color = "#3f5f5c", size=4.5, fontface = "bold", hjust = 0) +
+  geom_text(data=tibble(x = 0, y = 150, year = 1999), aes(x = x, y = y),
+            label = "Other sites to compare", color = "#9f817f", size=4.5, fontface = "bold", hjust = 0) +
+  facet_grid(rows = vars(year)) +
+  ylab("N days of consecutive flooding") + xlab("Day of Year") +
+  theme(panel.background = element_blank(), 
+        strip.background = element_blank(),
+        strip.text.y = element_text(angle = 0),
+        axis.text.y = element_blank(), 
+        axis.ticks.y = element_blank(),
+        plot.margin = unit(c(0, 0, 0, 0), "null")) +
+  ggtitle("TEST 10A: Compare flood events from other sites over time based on duration using rectangles")
+
+ggplot() +
+  # All "other" sites
+  geom_rect(
+    data = q_data_flood_span_yrs_others, fill = "#9f817f80", color = NA,
+    aes(xmin = start_Dt, xmax = end_Dt, ymin = 0, ymax = peak_consecutive_flood_days)) +
+  # This record-breaking site
+  geom_rect(
+    data = q_data_flood_span_yrs, fill = "#3f5f5c80", color = "#5e696f", size = 1,
+    aes(xmin = start_Dt, xmax = end_Dt, ymin = 0, ymax = peak_consecutive_flood_days)) +
+  facet_grid(rows = vars(site_no)) +
+  ylab("N days of consecutive flooding") + xlab("Day of Year") +
+  theme(panel.background = element_blank(), 
+        strip.background = element_blank(),
+        strip.text.y = element_text(angle = 0)) +
+  ggtitle("TEST 10B: Compare flood events from other sites over time based on duration using rectangles, keep timeline, grp by site")
+
+
+# Curved version with fixed year span issues
+q_data_flood_span_yrs_arc_others <- q_data_flood_span_yrs_others %>% 
+  # mutate(curvature = approx(c(0,365), c(-0.7, -0.05), peak_consecutive_flood_days)$y) %>% 
+  filter(x_start != x_end)
+
+ggplot() +
+  # All "other" sites
+  geom_curve(
+    data = q_data_flood_span_yrs_arc_others, 
+    aes(x = x_start, xend = x_end, y = year*100, yend = year*100), curvature = -0.25, color = "#9f817f80") +
+  # This record-breaking site
+  geom_curve(
+    data = q_data_flood_span_yrs, color = "#5e696f", size = 1,
+    aes(x = x_start, xend = x_end, y = year*100, yend = year*100), curvature = -0.25) +
+  ylim(min(q_data_flood_span_yrs$year)*100, (max(q_data_flood_span_yrs$year)+2)*100) +
+  ylab("N days of consecutive flooding") + xlab("Day of Year") +
+  geom_text(data=tibble(x = 0, y = 1999.5*100, year = 1999), aes(x = x, y = y),
+            label = "Site of interest", color = "#3f5f5c", size=4.5, fontface = "bold", hjust = 0) +
+  geom_text(data=tibble(x = 0, y = 1999*100, year = 1999), aes(x = x, y = y),
+            label = "Other sites to compare", color = "#9f817f", size=4.5, fontface = "bold", hjust = 0) +
+  theme(panel.background = element_blank(), 
+        strip.background = element_blank(),
+        strip.text.y = element_text(angle = 0),
+        axis.text.y = element_blank(),
+        axis.ticks = element_blank(),
+        plot.margin = unit(c(0, 0, 0, 0), "null")) +
+  ggtitle("TEST 11: Compare flood events from other sites over time based on duration using arcs")
+
+
+##### Line chart inspired by NYT Covid chart #####
+# https://www.nytimes.com/interactive/2020/11/25/us/coronavirus-cases-rising.html?action=click&module=Top%20Stories&pgtype=Homepage
+
+q_data_flood_seg <- q_data_flood %>% 
+  group_by(year) %>% 
+  summarize(peak_consecutive_flood_days = max(cumulative_consecutive_flood))
+q_data_flood_seg_others <- q_data_flood_others %>% 
+  group_by(year, site_no) %>% 
+  summarize(peak_consecutive_flood_days = max(cumulative_consecutive_flood))
+
+ggplot() +
+  # "OTHER" sites
+    # Sloped lines for other sites
+    geom_segment(data = q_data_flood_seg_others,
+                 aes(x = year - 1, xend = year, y = 0, yend = peak_consecutive_flood_days),
+                 size = 0.8, color = "#9f817f4D") +
+    # Straight lines connecting sloped to x-axis for other sites
+    geom_segment(data = q_data_flood_seg_others,
+                 aes(x = year, xend = year, y = 0, yend = peak_consecutive_flood_days),
+                 size = 0.8, color = "#d8cccb4D", linetype = "dotted") +
+  
+  # SITE 1
+    # Sloped lines for just site1
+    geom_segment(data = q_data_flood_seg, 
+                 aes(x = year - 1, xend = year, y = 0, yend = peak_consecutive_flood_days), 
+                 size = 0.8, color = "#3f5f5cCC") +
+    # Straight lines connecting sloped to x-axis for just site1
+    geom_segment(data = q_data_flood_seg,
+                 aes(x = year, xend = year, y = 0, yend = peak_consecutive_flood_days), 
+                 size = 0.8, color = "#b2bfbdCC", linetype = "dotted") +
+    # Dots for just site 1
+    geom_point(data = q_data_flood_seg, aes(x = year - 1, y = 0), color = "#3f5f5c") +
+    geom_point(data = q_data_flood_seg, aes(x = year, y = peak_consecutive_flood_days), color = "#3f5f5c") +
+  
+  # Styling
+  theme(panel.background = element_blank(),
+        axis.line.x = element_line(color="black", size = 0.5),
+        axis.line.y = element_line(color="black", size = 0.5)) +
+  ylab("Peak consecutive days of flooding") +
+  xlab("Year") +
+  ggtitle("TEST 12: Compare peak consecutive days of flood for events by year from other sites over time")
+
+# Try a version of the segment approach where you don't summarize by years
+# and keep as flood events instead. Things on the x-axis won't line up
+# neatly, so it may be crazy to look at.
+q_data_flood_seg_evt <- q_data_flood %>% 
+  filter(cumulative_consecutive_flood > 0) %>% 
+  mutate(GH = approx(site_curve_q, site_curve_gh, Flow)$y) %>% 
+  group_by(grp) %>% 
+  summarize(peak_gh = max(GH, na.rm = TRUE),
+            peak_consecutive_flood_days = max(cumulative_consecutive_flood),
+            evt_start = min(Date),
+            evt_end = max(Date))
+q_data_flood_seg_evt_others <- q_data_flood_others %>% 
+  filter(cumulative_consecutive_flood > 0) %>% 
+  group_by(grp, site_no) %>% 
+  summarize(peak_gh = max(GH, na.rm = TRUE),
+            peak_consecutive_flood_days = max(cumulative_consecutive_flood),
+            evt_start = min(Date),
+            evt_end = max(Date))
+
+ggplot() +
+  # "OTHER" sites
+  # Sloped lines for other sites
+  geom_segment(data = q_data_flood_seg_evt_others,
+               aes(x = evt_start, xend = evt_end, y = 0, yend = peak_gh),
+               size = 0.8, color = "#9f817f4D") +
+  # Straight lines connecting sloped to x-axis for other sites
+  geom_segment(data = q_data_flood_seg_evt_others,
+               aes(x = evt_end, xend = evt_end, y = 0, yend = peak_gh),
+               size = 0.8, color = "#d8cccb4D", linetype = "dotted") +
+
+  # SITE 1
+  # Sloped lines for just site1
+  geom_segment(data = q_data_flood_seg_evt, 
+               aes(x = evt_start, xend = evt_end, y = 0, yend = peak_gh), 
+               size = 0.8, color = "#3f5f5cCC") +
+  # Straight lines connecting sloped to x-axis for just site1
+  geom_segment(data = q_data_flood_seg_evt,
+               aes(x = evt_end, xend = evt_end, y = 0, yend = peak_gh), 
+               size = 0.8, color = "#b2bfbdCC", linetype = "dotted") +
+  # Dots for just site 1
+  geom_point(data = q_data_flood_seg_evt, aes(x = evt_start, y = 0), color = "#3f5f5c") +
+  geom_point(data = q_data_flood_seg_evt, aes(x = evt_end, y = peak_gh), color = "#3f5f5c") +
+  scale_y_log10() + 
+  # Styling
+  theme(panel.background = element_blank(),
+        axis.line.x = element_line(color="black", size = 0.5),
+        axis.line.y = element_line(color="black", size = 0.5)) +
+  ylab("Peak consecutive days of flooding") +
+  xlab("Date") +
+  ggtitle("TEST 13: Compare peak consecutive days of flood for events from other sites over time")
+

--- a/500_days_of_flooding/src/visualize.R
+++ b/500_days_of_flooding/src/visualize.R
@@ -1,0 +1,36 @@
+make_site_location_map <- function(filename, soi_info, ref_info, proj = "+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 +a=6370997 +b=6370997 +units=m +no_defs") {
+  conus_sf <- st_geometry(st_as_sf(maps::map("state", fill = TRUE, plot = FALSE))) %>% st_transform(proj)
+  
+  soi_sf <- st_as_sf(soi_info, coords = c("dec_long_va", "dec_lat_va"))
+  st_crs(soi_sf) <- "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+  soi_sf_proj <- soi_sf %>% st_transform(proj)
+  
+  ref_site_sf <- st_as_sf(ref_info, coords = c("dec_long_va", "dec_lat_va"))
+  st_crs(ref_site_sf) <- "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+  ref_site_sf_proj <- ref_site_sf %>% st_transform(proj)
+  
+  png(filename, width = 800, height = 500)
+  par(mar = c(0,0,0,0))
+  plot(st_geometry(conus_sf), col = "lightgrey", border = "white")
+  plot(st_geometry(soi_sf_proj), add = TRUE, pch = 20, cex = 3, col = "cornflowerblue")
+  plot(st_geometry(ref_site_sf_proj), add = TRUE, pch = 20, cex = 1.5, col = "salmon")
+  
+  # Place text for labels:
+  dims <- st_bbox(conus_sf)
+  x_pos <- dims$xmin + diff(c(dims$xmin, dims$xmax))*0.95 # Place at 70% along x
+  y_pos1 <- dims$ymin + diff(c(dims$ymin, dims$ymax))*0.30
+  y_pos2 <- dims$ymin + diff(c(dims$ymin, dims$ymax))*0.25
+  text(x_pos, c(y_pos1, y_pos2), labels = c("Site of interest", "Reference sites"), 
+       col = c("cornflowerblue", "salmon"), cex = 1.4, font = 2)
+  title("Sites used in streamgraph", cex.main = 2, col.main = "#323232", line = -2)
+  dev.off()
+}
+
+make_streamgraph <- function(filename, soi_data, ref_data) {
+  bind_rows(soi_data, ref_data) %>%
+    streamgraph(key="site_no", value="max_flood_evt_duration", date="year") %>% 
+    # sg_fill_manual(c("#F0D830", "#D8F0FF", "#909090", "#C0A890", "#C0C0C0")) %>% # 500 days palette
+    sg_fill_manual(c("#3f5f5c", "#9f817f", "#D8C0C0", "#A8A8A8", "#D8D8D8")) %>% # teal/rose palette
+    saveWidget(filename) 
+    
+}

--- a/500_days_of_flooding/src/visualize.R
+++ b/500_days_of_flooding/src/visualize.R
@@ -30,8 +30,8 @@ make_streamgraph <- function(filename, soi_data, ref_data) {
   # TODO: ordering so that the soi is always the correct color
   bind_rows(soi_data, ref_data) %>%
     streamgraph(key="site_no", value="max_flood_evt_duration", date="year") %>% 
-    # sg_fill_manual(c("#F0D830", "#D8F0FF", "#909090", "#C0A890", "#C0C0C0")) %>% # 500 days palette
-    sg_fill_manual(c("#3f5f5c", "#9f817f", "#D8C0C0", "#A8A8A8", "#D8D8D8")) %>% # teal/rose palette
+    sg_fill_manual(c("#F0D830", "#D8F0FF", "#909090", "#C0A890", "#C0C0C0")) %>% # 500 days palette
+    # sg_fill_manual(c("#3f5f5c", "#9f817f", "#D8C0C0", "#A8A8A8", "#D8D8D8")) %>% # teal/rose palette
     saveWidget(filename) 
     
 }

--- a/500_days_of_flooding/src/visualize.R
+++ b/500_days_of_flooding/src/visualize.R
@@ -27,6 +27,7 @@ make_site_location_map <- function(filename, soi_info, ref_info, proj = "+proj=l
 }
 
 make_streamgraph <- function(filename, soi_data, ref_data) {
+  # TODO: ordering so that the soi is always the correct color
   bind_rows(soi_data, ref_data) %>%
     streamgraph(key="site_no", value="max_flood_evt_duration", date="year") %>% 
     # sg_fill_manual(c("#F0D830", "#D8F0FF", "#909090", "#C0A890", "#C0C0C0")) %>% # 500 days palette

--- a/500_days_of_flooding/src/visualize.R
+++ b/500_days_of_flooding/src/visualize.R
@@ -26,12 +26,18 @@ make_site_location_map <- function(filename, soi_info, ref_info, proj = "+proj=l
   dev.off()
 }
 
-make_streamgraph <- function(filename, soi_data, ref_data) {
+make_streamgraph <- function(soi_data, ref_data) {
   # TODO: ordering so that the soi is always the correct color
   bind_rows(soi_data, ref_data) %>%
     streamgraph(key="site_no", value="max_flood_evt_duration", date="year") %>% 
-    sg_fill_manual(c("#F0D830", "#D8F0FF", "#909090", "#C0A890", "#C0C0C0")) %>% # 500 days palette
+    sg_fill_manual(c("#F0D830", "#D8F0FF", "#909090", "#C0A890", "#C0C0C0")) # 500 days palette
     # sg_fill_manual(c("#3f5f5c", "#9f817f", "#D8C0C0", "#A8A8A8", "#D8D8D8")) %>% # teal/rose palette
-    saveWidget(filename) 
-    
+}
+
+save_png <- function(widget, filename) {
+  htmltools::html_print(widget) %>%
+    normalizePath(.,winslash="/") %>%
+    gsub(x=.,pattern = ":/",replacement="://") %>%
+    paste0("file:///",.) %>%
+    webshot( file = filename, delay = 2 )
 }

--- a/500_days_of_flooding/src/visualize.R
+++ b/500_days_of_flooding/src/visualize.R
@@ -41,3 +41,23 @@ save_png <- function(widget, filename) {
     paste0("file:///",.) %>%
     webshot( file = filename, delay = 2 )
 }
+
+save_svg <- function(html_file, filename) {
+  # I couldn't figure out an automated way to do this but the NY Times svg_crowbar tool works great.
+  has_crowbar <- utils::menu(c("Yes", "No"), title="Do you already have the NY Times svg_crowbar tool?")
+  
+  if(has_crowbar == 2) {
+    message("To create the SVG, you need to first add theNY Times svg_crowbar tool to your bookmarks bar.\n Visit http://nytimes.github.io/svg-crowbar/ to learn how.\n\n")
+    readline("Hit enter once you have svg_crowbar")
+    has_crowbar <- 1
+  }
+  
+  if(has_crowbar == 1) {
+    message(sprintf("The streamgraph HTML will open in your browser. Once it opens, use\n svg_crowbar to download the SVG as `%s`", 
+                    filename))
+    Sys.sleep(4)
+    browseURL(html_file)
+    readline("Hit enter once you have downloaded the SVG")
+  }
+  
+}


### PR DESCRIPTION
Running `scmake()` results in two files: `site_locations_map.png` to show which sites are being used in the streamgraph and `streamgraph.html` which is the streamgraph itself. @collnell mentioned that they were unsuccessful with the [streamgraph package](https://github.com/hrbrmstr/streamgraph) on their version of R. I am on 3.6.1 and was able to use it without any issues.

Here are potential areas for improvement:

1. Work with Robert Mason to understand the 545 days ... I only get 534 even with counting all days with `P Ice`. 
2. Selection of streamgages. Currently just picked any that were within 25% of the main site's drainage area.
3. Figure out how to feature the other site with > 500 days. Currently only set up to feature the one, but there were two sites with > 500 days. Featuring them both on the same streamgraph would drastically change the look. Could do two separate ones that feature reference gages similar to the one featured.
4. There are other occasions where I noticed some of the reference gages had Flow even though they didn't have GH as well as GH but no Flow. Currently, only using GH for the reference gages, but perhaps we need to be a bit more sophisticated?

![image](https://user-images.githubusercontent.com/13220910/101226858-7357f480-365b-11eb-9ffb-3b93fc1139f1.png)

It is more squished than the test one I made yesterday. I want to investigate why it is different at some point.

![image](https://user-images.githubusercontent.com/13220910/101227326-0fcec680-365d-11eb-804f-712507936a57.png)


