### PR TITLE
built basic snow gif using code from vizstorm branch

### DIFF
--- a/snow_depth_gif/fxns.R
+++ b/snow_depth_gif/fxns.R
@@ -1,0 +1,128 @@
+# Functions used to build a simple snow depth animation
+
+fetch_snow_data <- function(date_format, snow_dir) {
+  
+  ymd_str <- format(date_format, "%Y%m%d") 
+  fn_out <- sprintf("%s/snow_raw_%s.dat", snow_dir, ymd_str)
+  
+  # construct URL
+  year <- format(date_format, "%Y")
+  month <- format(date_format, "%m")
+  month_str <- month.abb[as.numeric(month)]
+  
+  # Identify download location & tmp save location
+  tmp_dir <- sprintf("%s/tmp_dl", snow_dir)
+  if(!dir.exists(tmp_dir)) dir.create(tmp_dir)
+  ftp_base <- "ftp://sidads.colorado.edu/DATASETS/NOAA/G02158/unmasked/%s/%s"
+  ftp_folder <- sprintf(ftp_base, year, paste(month, month_str, sep = "_"))
+  url_tar <- sprintf('%s/SNODAS_unmasked_%s.tar', ftp_folder, ymd_str)
+  fn_tar <- file.path(tmp_dir, sprintf("%s.tar", ymd_str))
+  
+  # Download and unzip the snow data
+  download.file(url_tar, destfile = fn_tar, mode = "wb")
+  untar(fn_tar, exdir = tmp_dir)
+  
+  # Find the snow depth file and unzip
+  fn_tmp <- list.files(tmp_dir, full.names = TRUE)
+  fn_snow <- fn_tmp[grep("zz_ssmv11036", fn_tmp)]
+  fn_snow_dat <- fn_snow[grep(".dat", fn_snow)]
+  fn_zip <- fn_snow_dat[grep(ymd_str, fn_snow_dat)]
+  R.utils::gunzip(fn_zip, destname = fn_out, overwrite = TRUE)
+  
+  return(fn_out)
+}
+
+process_snow_raster <- function(snow_data_fn, states_sf) {
+  
+  # Size of SNODAS data
+  n_col <- 8192
+  n_row <- 4096
+  
+  # boundary extent for unmasked SNODAS
+  x0 <- -130.516666666661
+  x1 <- -62.2499999999975
+  y0 <- 24.0999999999990
+  y1 <- 58.2333333333310
+  
+  snow_depth <- readBin(snow_data_fn, integer(),
+                        n=n_row*n_col, size=2, signed=TRUE, endian='big')
+  snow_depth[snow_depth <= 0] <- 0
+  snow_depth_mat <- matrix(snow_depth, nrow = n_col)
+  
+  # Convert to raster
+  snow_raster <- raster::raster(ncol=n_col, nrow=n_row, xmn = x0, xmx = x1, ymn = y0, ymx = y1)
+  snow_raster <- raster::setValues(snow_raster, snow_depth)
+  
+  # Add the correct projection
+  # Source for WGS 84 projection: "Projecting SNODAS Data" section on https://nsidc.org/data/g02158
+  raster::crs(snow_raster) <- "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+  
+  # Now crop
+  snow_raster_crop <- raster::crop(snow_raster, states_sf)
+  
+  return(snow_raster_crop)
+  
+}
+
+download_data <- function(dates_to_see, states_sf, snow_dir) {
+  raster_fn_all <- c()
+  for(date_i in seq_along(dates_to_see)) {
+    raster_fn_out <- sprintf("%s/snow_ready_%s.rds", snow_dir, format(dates_to_see[date_i], "%Y%m%d"))
+    if(!file.exists(raster_fn_out)) {
+      date_raw_snow_fn <- fetch_snow_data(dates_to_see[date_i], snow_dir)
+      date_snow_raster <- process_snow_raster(date_raw_snow_fn, states_sf)
+      saveRDS(date_snow_raster, raster_fn_out)
+    }
+    raster_fn_all <- c(raster_fn_all, raster_fn_out)
+  }
+  return(raster_fn_all)
+}
+
+create_frames <- function(dates_to_see, raster_all_fn, snow_dir) {
+  
+  # Read in and put all raster obj in a list
+  snow_raster_all <- lapply(raster_fn_all, readRDS)
+  
+  # Make plot for each date
+  snow_breaks <- seq(0, 1000, by = 200)
+  snow_cols <- rev(scico::scico(length(snow_breaks), palette = 'devon'))
+  
+  frames_all <- c()
+  for(date_i in seq_along(dates_to_see)) {
+    frame_nm <- sprintf("%s/frame_snow_%s.png", snow_dir, format(dates_to_see[date_i], "%Y%m%d"))
+    png(frame_nm)
+    par(omi=c(0,0,0,0), mar=c(0,1,0,1), bty="n")
+    plot(snow_raster_all[[date_i]], axes=FALSE, breaks = snow_breaks, col = snow_cols)
+    plot(st_geometry(states_sf), add=TRUE)
+    mtext(dates_to_see[date_i], line = -4)
+    dev.off()
+    frames_all <- c(frames_all, frame_nm)
+  }
+  
+  return(frames_all)
+}
+
+make_gif <- function(anim_fn, frames) {
+  gif_tmp_dir <- sprintf("%s/magick", dirname(frames[1]))
+  if(!dir.exists(gif_tmp_dir)) dir.create(gif_tmp_dir)
+  
+  # Create a single string of all the frames going to be stitched together
+  #   to pass to ImageMagick commans.
+  frame_str <- paste(frames, collapse = " ")
+  
+  # Create the ImageMagick command to convert the files into a GIF
+  magick_command <- sprintf(
+    'convert -define registry:temporary-path=%s -limit memory 24GiB -delay %s -loop 0 %s %s',
+    gif_tmp_dir, 50, frame_str, anim_fn)
+  
+  # If you are on a Windows machine, you will need to have `magick` added before the command
+  if(Sys.info()[['sysname']] == "Windows") {
+    magick_command <- sprintf('magick %s', magick_command)
+  }
+  
+  # Now actually run the command and create the GIF
+  system(magick_command)
+  
+  return(anim_fn)
+}
+

--- a/snow_depth_gif/readme.md
+++ b/snow_depth_gif/readme.md
@@ -1,0 +1,28 @@
+# This code creates a rough gif of snow depth if you provide dates and states
+
+Change the dates used and the states you would like it to be cropped to. The code will download the data, process it, and then plot in a map. To use the functions stored in `fxns.R`, run the following code. This example takes about 20 minutes to run in total.
+
+```r
+library(sf)
+library(raster)
+source("fxns.R")
+
+# The rest of the code operates on whatever you put for `snow_dir` being a directory in your working directory
+snow_dir <- "test_snow"
+if(!dir.exists(snow_dir)) dir.create(snow_dir)
+
+# 0. Config: Setup the dates to use and the states to crop to
+dates_to_see <- seq(as.Date("2021-02-20"), as.Date("2021-03-10"), by = 1)
+states_sf <- st_as_sf(maps::map("state", c("ohio", "pennsylvania", "maryland", "new york", "west virginia", "virginia"), plot=FALSE, fill=TRUE))
+
+# 1. Fetch and Process: Download and process data for each day
+raster_fn_all <- download_data(dates_to_see, states_sf, snow_dir)
+
+# 2. Visualize: Create individual timestep PNGs of the snow depth maps
+frames_all <- create_frames(dates_to_see, raster_fn_all, snow_dir)
+
+# 3. Animate: Create the animation
+make_gif("snow_anim.gif", frames_all)
+```
+
+![](https://user-images.githubusercontent.com/13220910/113920576-8fef6f00-97aa-11eb-9475-f86cb021b982.gif)

--- a/snow_depth_gif/readme.md
+++ b/snow_depth_gif/readme.md
@@ -26,3 +26,11 @@ make_gif("snow_anim.gif", frames_all)
 ```
 
 ![](https://user-images.githubusercontent.com/13220910/113920576-8fef6f00-97aa-11eb-9475-f86cb021b982.gif)
+
+# Further development / considerations
+
+Per Colleen's comments to the original PR, there is more work that can be done to refine this approach. Please read the considerations below before using the code as-is.
+
+1. The scale bar moves throughout the animation, reason is unknown
+2. Consider a continuous instead of discrete color scale
+3. This is currently set up to use snow depth, but snow-water equivalent (SWE) might be more appropriate for hydrology applications, especially flooding. Consider using SWE instead (this would involve downloading different data, see [Colleen's comment here](https://github.com/USGS-VIZLAB/viz-scratch/pull/69#issuecomment-815992879) for a bit more detail)


### PR DESCRIPTION
As part of river conditions, we wanted to see if we could make a statement about a rain-on-snow event being a major cause of high water in the region so I put together this quick GIF by stealing code from the `MidwestWinterFlooding-2019` branch https://github.com/USGS-VIZLAB/vizstorm-GIF/tree/MidwestWinterFlooding-2019. Since this decouples that workflow from the `scipiper` ways, I thought it would be good to capture here in case others need to do something similar. See readme for how to run. 

Produces:

![](https://user-images.githubusercontent.com/13220910/113920576-8fef6f00-97aa-11eb-9475-f86cb021b982.gif)